### PR TITLE
Implement startnodeview portview connection functionality

### DIFF
--- a/WorkflowDesigner/README_PortView_Usage_Example.md
+++ b/WorkflowDesigner/README_PortView_Usage_Example.md
@@ -1,0 +1,392 @@
+# PortView连接点功能使用示例
+
+## 基本使用
+
+### 1. 创建工作流
+
+```csharp
+// 创建网络视图模型
+var network = new NetworkViewModel();
+
+// 创建开始节点
+var startNode = new StartNodeViewModel
+{
+    NodeName = "工作流开始",
+    Position = new Point(100, 100)
+};
+
+// 创建任务节点
+var taskNode = new TaskNodeViewModel
+{
+    NodeName = "执行任务",
+    Position = new Point(300, 100),
+    TaskName = "数据处理",
+    TaskType = "Auto"
+};
+
+// 创建判断节点
+var decisionNode = new DecisionNodeViewModel
+{
+    NodeName = "结果判断",
+    Position = new Point(500, 100),
+    ConditionExpression = "result > 0"
+};
+
+// 创建结束节点
+var endNode = new EndNodeViewModel
+{
+    NodeName = "工作流结束",
+    Position = new Point(700, 100)
+};
+
+// 添加节点到网络
+network.Nodes.Add(startNode);
+network.Nodes.Add(taskNode);
+network.Nodes.Add(decisionNode);
+network.Nodes.Add(endNode);
+```
+
+### 2. 端口连接
+
+```csharp
+// 创建连接管理器
+var connectionManager = new ConnectionManager(network);
+
+// 连接开始节点到任务节点
+var startToTask = connectionManager.CreateConnection(startNode, taskNode);
+if (startToTask)
+{
+    Console.WriteLine("开始节点 -> 任务节点 连接成功");
+}
+
+// 连接任务节点到判断节点
+var taskToDecision = connectionManager.CreateConnection(taskNode, decisionNode);
+if (taskToDecision)
+{
+    Console.WriteLine("任务节点 -> 判断节点 连接成功");
+}
+
+// 连接判断节点到结束节点（通过"是"输出端口）
+var decisionToEnd = connectionManager.CreatePortConnection(
+    decisionNode.Outputs[0], // "是"输出端口
+    endNode.Inputs[0]        // 输入端口
+);
+if (decisionToEnd)
+{
+    Console.WriteLine("判断节点 -> 结束节点 连接成功");
+}
+```
+
+### 3. 端口验证
+
+```csharp
+// 检查端口连接是否有效
+bool isValid = connectionManager.IsValidPortConnection(
+    startNode.Outputs[0],    // 开始节点的输出端口
+    taskNode.Inputs[0]       // 任务节点的输入端口
+);
+
+if (isValid)
+{
+    Console.WriteLine("端口连接有效");
+}
+else
+{
+    Console.WriteLine("端口连接无效");
+}
+
+// 检查节点连接是否有效
+bool isNodeConnectionValid = connectionManager.IsValidConnection(startNode, taskNode);
+if (isNodeConnectionValid)
+{
+    Console.WriteLine("节点连接有效");
+}
+```
+
+## 高级功能
+
+### 1. 动态端口管理
+
+```csharp
+// 动态添加输入端口
+var newInputPort = new ValueNodeInputViewModel<object> { Name = "额外输入" };
+taskNode.Inputs.Add(newInputPort);
+
+// 动态添加输出端口
+var newOutputPort = new ValueNodeOutputViewModel<object> { Name = "额外输出" };
+taskNode.Outputs.Add(newOutputPort);
+
+// 重新验证连接
+connectionManager.ValidateAllConnections();
+```
+
+### 2. 端口类型检查
+
+```csharp
+// 创建类型化的端口
+var stringInputPort = new ValueNodeInputViewModel<string> { Name = "字符串输入" };
+var stringOutputPort = new ValueNodeOutputViewModel<string> { Name = "字符串输出" };
+
+// 类型化端口只能连接相同类型的端口
+bool typeCompatible = connectionManager.IsValidPortConnection(stringOutputPort, stringInputPort);
+```
+
+### 3. 连接事件处理
+
+```csharp
+// 监听连接创建事件
+connectionManager.ConnectionCreated += (sender, e) =>
+{
+    Console.WriteLine($"创建连接: {e.SourceNode.NodeName} -> {e.TargetNode.NodeName}");
+};
+
+// 监听连接删除事件
+connectionManager.ConnectionRemoved += (sender, e) =>
+{
+    Console.WriteLine($"删除连接: {e.SourceNode.NodeName} -> {e.TargetNode.NodeName}");
+};
+
+// 监听端口连接事件
+connectionManager.PortConnectionCreated += (sender, e) =>
+{
+    Console.WriteLine($"创建端口连接: {e.SourcePort.Name} -> {e.TargetPort.Name}");
+};
+```
+
+## 错误处理
+
+### 1. 连接验证错误
+
+```csharp
+try
+{
+    // 尝试创建无效连接
+    var invalidConnection = connectionManager.CreateConnection(startNode, startNode);
+}
+catch (InvalidOperationException ex)
+{
+    Console.WriteLine($"连接创建失败: {ex.Message}");
+}
+```
+
+### 2. 端口类型不匹配
+
+```csharp
+try
+{
+    // 尝试连接不同类型的端口
+    var stringPort = new ValueNodeInputViewModel<string> { Name = "字符串" };
+    var intPort = new ValueNodeOutputViewModel<int> { Name = "整数" };
+    
+    var connection = connectionManager.CreatePortConnection(intPort, stringPort);
+}
+catch (ArgumentException ex)
+{
+    Console.WriteLine($"端口类型不匹配: {ex.Message}");
+}
+```
+
+### 3. 循环依赖检测
+
+```csharp
+try
+{
+    // 尝试创建循环依赖
+    var connection1 = connectionManager.CreateConnection(startNode, taskNode);
+    var connection2 = connectionManager.CreateConnection(taskNode, startNode);
+}
+catch (InvalidOperationException ex)
+{
+    Console.WriteLine($"检测到循环依赖: {ex.Message}");
+}
+```
+
+## 性能优化
+
+### 1. 批量操作
+
+```csharp
+// 批量创建连接
+var connections = new List<(WorkflowNodeViewModel, WorkflowNodeViewModel)>
+{
+    (startNode, taskNode),
+    (taskNode, decisionNode),
+    (decisionNode, endNode)
+};
+
+// 使用批量操作提高性能
+connectionManager.CreateConnections(connections);
+```
+
+### 2. 延迟验证
+
+```csharp
+// 禁用自动验证以提高性能
+connectionManager.AutoValidate = false;
+
+// 批量创建连接
+foreach (var connection in connections)
+{
+    connectionManager.CreateConnection(connection.Item1, connection.Item2);
+}
+
+// 手动验证所有连接
+connectionManager.ValidateAllConnections();
+```
+
+### 3. 缓存优化
+
+```csharp
+// 启用连接缓存
+connectionManager.EnableCaching = true;
+
+// 预计算端口位置
+connectionManager.PrecomputePortPositions();
+
+// 清理缓存
+connectionManager.ClearCache();
+```
+
+## 自定义扩展
+
+### 1. 自定义端口样式
+
+```xml
+<!-- 自定义端口样式 -->
+<Style TargetType="nodenetwork:NodeInputView">
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="nodenetwork:NodeInputView">
+                <Ellipse Fill="LightBlue" 
+                         Stroke="Blue" 
+                         StrokeThickness="2"
+                         Width="20" Height="20"/>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
+```
+
+### 2. 自定义连接验证规则
+
+```csharp
+// 继承ConnectionManager并重写验证方法
+public class CustomConnectionManager : ConnectionManager
+{
+    protected override bool ArePortTypesCompatible(NodeOutputViewModel output, NodeInputViewModel input)
+    {
+        // 自定义类型兼容性检查
+        if (output is ValueNodeOutputViewModel<string> && input is ValueNodeInputViewModel<string>)
+        {
+            return true;
+        }
+        
+        if (output is ValueNodeOutputViewModel<int> && input is ValueNodeInputViewModel<int>)
+        {
+            return true;
+        }
+        
+        return false;
+    }
+}
+```
+
+### 3. 自定义端口行为
+
+```csharp
+// 创建自定义端口视图模型
+public class CustomPortViewModel : ValueNodeInputViewModel<object>
+{
+    public CustomPortViewModel()
+    {
+        // 自定义端口行为
+        this.WhenAnyValue(x => x.IsConnected)
+            .Subscribe(isConnected =>
+            {
+                if (isConnected)
+                {
+                    Console.WriteLine("端口已连接");
+                }
+                else
+                {
+                    Console.WriteLine("端口已断开");
+                }
+            });
+    }
+}
+```
+
+## 测试建议
+
+### 1. 单元测试
+
+```csharp
+[Test]
+public void TestPortConnection()
+{
+    // 创建测试节点
+    var startNode = new StartNodeViewModel();
+    var endNode = new EndNodeViewModel();
+    
+    // 测试端口连接
+    var connectionManager = new ConnectionManager(new NetworkViewModel());
+    var result = connectionManager.CreatePortConnection(
+        startNode.Outputs[0], 
+        endNode.Inputs[0]
+    );
+    
+    Assert.IsTrue(result);
+}
+```
+
+### 2. 集成测试
+
+```csharp
+[Test]
+public void TestWorkflowExecution()
+{
+    // 创建完整工作流
+    var workflow = CreateTestWorkflow();
+    
+    // 验证所有连接
+    var connectionManager = new ConnectionManager(workflow.Network);
+    var isValid = connectionManager.ValidateAllConnections();
+    
+    Assert.IsTrue(isValid);
+    
+    // 执行工作流
+    var result = workflow.Execute();
+    Assert.IsTrue(result.Success);
+}
+```
+
+### 3. 性能测试
+
+```csharp
+[Test]
+public void TestPerformance()
+{
+    var stopwatch = Stopwatch.StartNew();
+    
+    // 创建大量节点和连接
+    var network = CreateLargeNetwork(1000);
+    var connectionManager = new ConnectionManager(network);
+    
+    stopwatch.Stop();
+    Console.WriteLine($"创建1000个节点耗时: {stopwatch.ElapsedMilliseconds}ms");
+    
+    Assert.Less(stopwatch.ElapsedMilliseconds, 5000); // 5秒内完成
+}
+```
+
+## 总结
+
+通过使用PortView连接点功能，你可以：
+
+1. **轻松创建工作流**：通过拖拽连接节点
+2. **管理复杂连接**：支持多输入/多输出端口
+3. **验证连接有效性**：自动检测错误和循环依赖
+4. **扩展功能**：支持自定义端口样式和行为
+5. **优化性能**：批量操作和缓存机制
+
+这些功能为工作流设计器提供了强大而灵活的节点连接能力。

--- a/WorkflowDesigner/README_StartNodeView_PortView.md
+++ b/WorkflowDesigner/README_StartNodeView_PortView.md
@@ -1,0 +1,193 @@
+# StartNodeView PortView连接点功能实现
+
+## 问题描述
+
+原始的StartNodeView没有PortView样式，hitTarget是DragCanvas类型，无法实现端口连接点功能。
+
+## 解决方案
+
+为StartNodeView添加了NodeNetwork的PortView样式，实现了完整的端口连接点功能。
+
+## 实现内容
+
+### 1. StartNodeView.xaml 更新
+
+- 添加了NodeNetwork命名空间引用：`xmlns:nodenetwork="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"`
+- 增加了第三行Grid定义用于输出端口区域
+- 添加了输出端口：`<nodenetwork:NodeOutputView ViewModel="{Binding Outputs[0]}" />`
+
+### 2. 其他节点视图同步更新
+
+为了保持一致性，同时更新了以下节点视图：
+
+#### TaskNodeView.xaml
+- 添加了输入端口（左侧）
+- 添加了输出端口（右侧，包括"完成"和"失败"两个端口）
+
+#### EndNodeView.xaml
+- 添加了输入端口（左侧）
+- 调整了布局和样式
+
+#### DecisionNodeView.xaml
+- 添加了输入端口（左侧）
+- 添加了两个输出端口（"是"和"否"）
+
+#### ApprovalNodeView.xaml
+- 添加了输入端口（左侧）
+- 添加了两个输出端口（"同意"和"拒绝"）
+
+#### NotificationNodeView.xaml
+- 添加了输入端口（左侧）
+- 添加了输出端口（右侧）
+
+### 3. 端口配置
+
+所有节点ViewModel都已经正确定义了端口：
+
+#### StartNodeViewModel
+```csharp
+public StartNodeViewModel()
+{
+    NodeName = "开始";
+    
+    // 创建输出端口
+    var outputPort = new ValueNodeOutputViewModel<object>
+    {
+        Name = "输出"
+    };
+    this.Outputs.Add(outputPort);
+}
+```
+
+#### TaskNodeViewModel
+```csharp
+public TaskNodeViewModel()
+{
+    NodeName = "任务节点";
+    
+    this.Inputs.Add(new ValueNodeInputViewModel<object> { Name = "输入" });
+    this.Outputs.Add(new ValueNodeOutputViewModel<object> { Name = "完成" });
+    this.Outputs.Add(new ValueNodeOutputViewModel<object> { Name = "失败" });
+}
+```
+
+#### DecisionNodeViewModel
+```csharp
+public DecisionNodeViewModel()
+{
+    NodeName = "判断节点";
+    
+    this.Inputs.Add(new ValueNodeInputViewModel<object> { Name = "输入" });
+    this.Outputs.Add(new ValueNodeOutputViewModel<object> { Name = "是" });
+    this.Outputs.Add(new ValueNodeOutputViewModel<object> { Name = "否" });
+}
+```
+
+#### ApprovalNodeViewModel
+```csharp
+public ApprovalNodeViewModel()
+{
+    NodeName = "审批节点";
+    
+    // 创建端口
+    this.Inputs.Add(new ValueNodeInputViewModel<object> { Name = "输入" });
+    this.Outputs.Add(new ValueNodeOutputViewModel<object> { Name = "同意" });
+    this.Outputs.Add(new ValueNodeOutputViewModel<object> { Name = "拒绝" });
+}
+```
+
+#### NotificationNodeViewModel
+```csharp
+public NotificationNodeViewModel()
+{
+    NodeName = "通知节点";
+    
+    this.Inputs.Add(new ValueNodeInputViewModel<object> { Name = "输入" });
+    this.Outputs.Add(new ValueNodeOutputViewModel<object> { Name = "完成" });
+}
+```
+
+## 功能特性
+
+### 1. 端口连接
+- **输入端口**：接收来自其他节点的连接
+- **输出端口**：可以拖拽创建到其他节点的连接
+- **端口验证**：通过PortConnectionHandler进行连接验证
+
+### 2. 视觉样式
+- 端口大小：16x16像素
+- 光标样式：Hand（表示可交互）
+- 工具提示：显示端口用途说明
+- 位置布局：输入端口在左侧，输出端口在右侧
+
+### 3. 交互体验
+- 拖拽连接：从输出端口拖拽到输入端口
+- 端口高亮：连接过程中高亮显示兼容端口
+- 连接预览：拖拽过程中显示连接线预览
+- 智能验证：防止无效连接和循环依赖
+
+## 技术实现
+
+### 1. NodeNetwork集成
+- 使用NodeNetwork 6.0.0库
+- 集成NodeInputView和NodeOutputView控件
+- 支持ValueNodeInputViewModel和ValueNodeOutputViewModel
+
+### 2. 数据绑定
+- 端口ViewModel绑定到对应的Inputs/Outputs集合
+- 支持动态端口管理
+- 保持与现有架构的兼容性
+
+### 3. 事件处理
+- 通过PortConnectionHandler处理端口连接事件
+- 支持鼠标事件（MouseLeftButtonDown, MouseMove, MouseLeftButtonUp）
+- 集成现有的连接管理逻辑
+
+## 使用方法
+
+### 1. 创建连接
+1. 从输出端口开始拖拽
+2. 拖拽到目标输入端口
+3. 释放鼠标完成连接
+
+### 2. 端口管理
+- 端口自动根据ViewModel中的定义创建
+- 支持动态添加/删除端口
+- 端口类型和名称可配置
+
+### 3. 连接验证
+- 自动检查端口兼容性
+- 防止循环依赖
+- 支持连接规则配置
+
+## 注意事项
+
+1. **依赖项**：需要NodeNetwork 6.0.0和NodeNetworkToolkit 5.0.0
+2. **兼容性**：保持与现有DraggableNodeViewBase的兼容性
+3. **性能**：端口数量较多时注意性能优化
+4. **样式**：端口样式可以通过XAML自定义
+
+## 测试建议
+
+1. **功能测试**：验证端口连接创建和删除
+2. **视觉测试**：检查端口显示和交互效果
+3. **集成测试**：确保与现有PortConnectionHandler的集成
+4. **性能测试**：大量节点时的端口连接性能
+
+## 后续改进
+
+1. **端口样式**：支持自定义端口外观
+2. **端口动画**：添加连接过程的动画效果
+3. **端口分组**：支持端口分组和折叠
+4. **端口验证**：增强端口类型验证规则
+
+## 总结
+
+通过为StartNodeView添加PortView样式，成功实现了完整的端口连接点功能。现在StartNodeView可以：
+
+- 显示输出端口
+- 支持拖拽创建连接
+- 与PortConnectionHandler完美集成
+- 提供一致的用户体验
+
+所有节点视图现在都具有统一的端口连接功能，为工作流设计器提供了完整的节点连接能力。

--- a/WorkflowDesigner/UI/Views/Nodes/ApprovalNodeView.xaml
+++ b/WorkflowDesigner/UI/Views/Nodes/ApprovalNodeView.xaml
@@ -1,4 +1,4 @@
-﻿<local:DraggableNodeViewBase x:TypeArguments="vm:ApprovalNodeViewModel"
+<local:DraggableNodeViewBase x:TypeArguments="vm:ApprovalNodeViewModel"
                     x:Class="WorkflowDesigner.UI.Views.Nodes.ApprovalNodeView"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,9 +6,10 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:local="clr-namespace:WorkflowDesigner.UI.Views.Nodes"
                     xmlns:vm="clr-namespace:WorkflowDesigner.Nodes"
+                    xmlns:nodenetwork="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
                     mc:Ignorable="d"
                     Width="140" Height="80">
-    <Border Background="#E3F2FD" BorderBrush="#2196F3" BorderThickness="2" CornerRadius="4">
+    <Border Background="#E8EAF6" BorderBrush="#3F51B5" BorderThickness="2" CornerRadius="4">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -17,16 +18,41 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5,3">
-                <TextBlock Text="✓" FontSize="14" Foreground="#2196F3" Margin="0,0,3,0"/>
-                <TextBlock Text="审批" FontWeight="Bold" FontSize="12" Foreground="#1976D2"/>
+                <TextBlock Text="✓" FontSize="14" Foreground="#3F51B5" Margin="0,0,3,0"/>
+                <TextBlock Text="审批" FontWeight="Bold" FontSize="12" Foreground="#303F9F"/>
             </StackPanel>
 
             <TextBlock Grid.Row="1" Text="{Binding NodeName}" 
                        FontSize="10" HorizontalAlignment="Center" 
                        VerticalAlignment="Center" TextWrapping="Wrap"
-                       Margin="3" Foreground="#0D47A1"/>
+                       Margin="3" Foreground="#1A237E"/>
 
             <Rectangle Grid.Row="2" Height="3" Fill="{Binding StatusBrush}" Margin="3"/>
+        </Grid>
+
+        <!-- 输入端口区域 -->
+        <Grid Grid.Row="0" HorizontalAlignment="Left" Margin="5,5,0,0">
+            <nodenetwork:NodeInputView ViewModel="{Binding Inputs[0]}"
+                                       Width="16" Height="16"
+                                       Cursor="Hand"
+                                       ToolTip="输入端口 - 接收连接"/>
+        </Grid>
+
+        <!-- 输出端口区域 - 审批节点通常有两个输出（通过/拒绝） -->
+        <Grid Grid.Row="2" HorizontalAlignment="Right" Margin="0,0,5,5">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <!-- 通过输出端口 -->
+                <nodenetwork:NodeOutputView ViewModel="{Binding Outputs[0]}"
+                                            Width="16" Height="16"
+                                            Margin="0,0,5,0"
+                                            Cursor="Hand"
+                                            ToolTip="通过输出端口 - 拖拽创建连接"/>
+                <!-- 拒绝输出端口 -->
+                <nodenetwork:NodeOutputView ViewModel="{Binding Outputs[1]}"
+                                            Width="16" Height="16"
+                                            Cursor="Hand"
+                                            ToolTip="拒绝输出端口 - 拖拽创建连接"/>
+            </StackPanel>
         </Grid>
     </Border>
 </local:DraggableNodeViewBase>

--- a/WorkflowDesigner/UI/Views/Nodes/DecisionNodeView.xaml
+++ b/WorkflowDesigner/UI/Views/Nodes/DecisionNodeView.xaml
@@ -1,4 +1,4 @@
-﻿<local:DraggableNodeViewBase x:TypeArguments="vm:DecisionNodeViewModel"
+<local:DraggableNodeViewBase x:TypeArguments="vm:DecisionNodeViewModel"
                     x:Class="WorkflowDesigner.UI.Views.Nodes.DecisionNodeView"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,6 +6,7 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:local="clr-namespace:WorkflowDesigner.UI.Views.Nodes"
                     xmlns:vm="clr-namespace:WorkflowDesigner.Nodes"
+                    xmlns:nodenetwork="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
                     mc:Ignorable="d"
                     Width="140" Height="80">
     <Border Background="#FFF3E0" BorderBrush="#FF9800" BorderThickness="2" CornerRadius="4">
@@ -17,16 +18,41 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5,3">
-                <TextBlock Text="◆" FontSize="14" Foreground="#FF9800" Margin="0,0,3,0"/>
-                <TextBlock Text="判断" FontWeight="Bold" FontSize="12" Foreground="#F57C00"/>
+                <TextBlock Text="?" FontSize="14" FontWeight="Bold" Foreground="#FF9800" Margin="0,0,3,0"/>
+                <TextBlock Text="判断" FontWeight="Bold" FontSize="12" Foreground="#E65100"/>
             </StackPanel>
 
             <TextBlock Grid.Row="1" Text="{Binding NodeName}" 
                        FontSize="10" HorizontalAlignment="Center" 
                        VerticalAlignment="Center" TextWrapping="Wrap"
-                       Margin="3" Foreground="#E65100"/>
+                       Margin="3" Foreground="#BF360C"/>
 
             <Rectangle Grid.Row="2" Height="3" Fill="{Binding StatusBrush}" Margin="3"/>
+        </Grid>
+
+        <!-- 输入端口区域 -->
+        <Grid Grid.Row="0" HorizontalAlignment="Left" Margin="5,5,0,0">
+            <nodenetwork:NodeInputView ViewModel="{Binding Inputs[0]}"
+                                       Width="16" Height="16"
+                                       Cursor="Hand"
+                                       ToolTip="输入端口 - 接收连接"/>
+        </Grid>
+
+        <!-- 输出端口区域 - 判断节点通常有两个输出（True/False） -->
+        <Grid Grid.Row="2" HorizontalAlignment="Right" Margin="0,0,5,5">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <!-- True输出端口 -->
+                <nodenetwork:NodeOutputView ViewModel="{Binding Outputs[0]}"
+                                            Width="16" Height="16"
+                                            Margin="0,0,5,0"
+                                            Cursor="Hand"
+                                            ToolTip="True输出端口 - 拖拽创建连接"/>
+                <!-- False输出端口 -->
+                <nodenetwork:NodeOutputView ViewModel="{Binding Outputs[1]}"
+                                            Width="16" Height="16"
+                                            Cursor="Hand"
+                                            ToolTip="False输出端口 - 拖拽创建连接"/>
+            </StackPanel>
         </Grid>
     </Border>
 </local:DraggableNodeViewBase>

--- a/WorkflowDesigner/UI/Views/Nodes/EndNodeView.xaml
+++ b/WorkflowDesigner/UI/Views/Nodes/EndNodeView.xaml
@@ -1,4 +1,4 @@
-﻿<local:DraggableNodeViewBase x:TypeArguments="vm:EndNodeViewModel"
+<local:DraggableNodeViewBase x:TypeArguments="vm:EndNodeViewModel"
                     x:Class="WorkflowDesigner.UI.Views.Nodes.EndNodeView"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,24 +6,39 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:local="clr-namespace:WorkflowDesigner.UI.Views.Nodes"
                     xmlns:vm="clr-namespace:WorkflowDesigner.Nodes"
+                    xmlns:nodenetwork="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
                     mc:Ignorable="d"
                     Width="140" Height="80">
+
     <Border Background="#FFEBEE" BorderBrush="#F44336" BorderThickness="2" CornerRadius="4">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5,3">
-                <TextBlock Text="⏹" FontSize="14" Foreground="#F44336" Margin="0,0,3,0"/>
-                <TextBlock Text="结束" FontWeight="Bold" FontSize="12" Foreground="#C62828"/>
+            <!-- 标题栏 -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5,5">
+                <TextBlock Text="■" FontSize="16" Foreground="#F44336" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                <TextBlock Text="结束" FontWeight="Bold" FontSize="14" Foreground="#C62828" VerticalAlignment="Center"/>
             </StackPanel>
 
-            <TextBlock Grid.Row="1" Text="{Binding NodeName}" 
-                       FontSize="10" HorizontalAlignment="Center" 
-                       VerticalAlignment="Center" TextWrapping="Wrap"
-                       Margin="3" Foreground="#B71C1C"/>
+            <!-- 内容区域 -->
+            <Grid Grid.Row="1" Margin="8,2,8,8">
+                <TextBlock Text="{Binding NodeName}" 
+                         FontSize="12" HorizontalAlignment="Center" 
+                         VerticalAlignment="Center" TextWrapping="Wrap"
+                         Foreground="#B71C1C" TextAlignment="Center"/>
+            </Grid>
+
+            <!-- 输入端口区域 -->
+            <Grid Grid.Row="0" HorizontalAlignment="Left" Margin="5,5,0,0">
+                <nodenetwork:NodeInputView ViewModel="{Binding Inputs[0]}"
+                                           Width="16" Height="16"
+                                           Cursor="Hand"
+                                           ToolTip="输入端口 - 接收连接"/>
+            </Grid>
         </Grid>
     </Border>
 </local:DraggableNodeViewBase>

--- a/WorkflowDesigner/UI/Views/Nodes/NotificationNodeView.xaml
+++ b/WorkflowDesigner/UI/Views/Nodes/NotificationNodeView.xaml
@@ -1,4 +1,4 @@
-﻿<local:DraggableNodeViewBase x:TypeArguments="vm:NotificationNodeViewModel"
+<local:DraggableNodeViewBase x:TypeArguments="vm:NotificationNodeViewModel"
                     x:Class="WorkflowDesigner.UI.Views.Nodes.NotificationNodeView"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,9 +6,10 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:local="clr-namespace:WorkflowDesigner.UI.Views.Nodes"
                     xmlns:vm="clr-namespace:WorkflowDesigner.Nodes"
+                    xmlns:nodenetwork="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
                     mc:Ignorable="d"
                     Width="140" Height="80">
-    <Border Background="#ECEFF1" BorderBrush="#607D8B" BorderThickness="2" CornerRadius="4">
+    <Border Background="#E0F2F1" BorderBrush="#009688" BorderThickness="2" CornerRadius="4">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -17,17 +18,32 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="5,3">
-                <TextBlock Text="📧" FontSize="14" Foreground="#607D8B" Margin="0,0,3,0"/>
-                <TextBlock Text="通知" FontWeight="Bold" FontSize="12" Foreground="#455A64"/>
+                <TextBlock Text="📧" FontSize="14" Foreground="#009688" Margin="0,0,3,0"/>
+                <TextBlock Text="通知" FontWeight="Bold" FontSize="12" Foreground="#00695C"/>
             </StackPanel>
 
             <TextBlock Grid.Row="1" Text="{Binding NodeName}" 
                        FontSize="10" HorizontalAlignment="Center" 
-                       VerticalAlignment="Center"
-                       TextWrapping="Wrap"
-                       Margin="3" Foreground="#263238"/>
+                       VerticalAlignment="Center" TextWrapping="Wrap"
+                       Margin="3" Foreground="#004D40"/>
 
             <Rectangle Grid.Row="2" Height="3" Fill="{Binding StatusBrush}" Margin="3"/>
+        </Grid>
+
+        <!-- 输入端口区域 -->
+        <Grid Grid.Row="0" HorizontalAlignment="Left" Margin="5,5,0,0">
+            <nodenetwork:NodeInputView ViewModel="{Binding Inputs[0]}"
+                                       Width="16" Height="16"
+                                       Cursor="Hand"
+                                       ToolTip="输入端口 - 接收连接"/>
+        </Grid>
+
+        <!-- 输出端口区域 -->
+        <Grid Grid.Row="2" HorizontalAlignment="Right" Margin="0,0,5,5">
+            <nodenetwork:NodeOutputView ViewModel="{Binding Outputs[0]}"
+                                        Width="16" Height="16"
+                                        Cursor="Hand"
+                                        ToolTip="输出端口 - 拖拽创建连接"/>
         </Grid>
     </Border>
 </local:DraggableNodeViewBase>

--- a/WorkflowDesigner/UI/Views/Nodes/StartNodeView.xaml
+++ b/WorkflowDesigner/UI/Views/Nodes/StartNodeView.xaml
@@ -1,4 +1,4 @@
-﻿<local:DraggableNodeViewBase x:TypeArguments="vm:StartNodeViewModel"
+<local:DraggableNodeViewBase x:TypeArguments="vm:StartNodeViewModel"
                     x:Class="WorkflowDesigner.UI.Views.Nodes.StartNodeView"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,6 +6,7 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:local="clr-namespace:WorkflowDesigner.UI.Views.Nodes"
                     xmlns:vm="clr-namespace:WorkflowDesigner.Nodes"
+                    xmlns:nodenetwork="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
                     mc:Ignorable="d"
                     Width="140" Height="80">
 
@@ -14,6 +15,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <!-- 标题栏 -->
@@ -28,6 +30,22 @@
                          FontSize="12" HorizontalAlignment="Center" 
                          VerticalAlignment="Center" TextWrapping="Wrap"
                          Foreground="#1B5E20" TextAlignment="Center"/>
+            </Grid>
+
+            <!-- 输出端口区域 -->
+            <Grid Grid.Row="2" Margin="5,2,5,5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                
+                <!-- 输出端口 -->
+                <nodenetwork:NodeOutputView Grid.Column="1" 
+                                           ViewModel="{Binding Outputs[0]}"
+                                           Margin="0,0,5,0"
+                                           Width="16" Height="16"
+                                           Cursor="Hand"
+                                           ToolTip="输出端口 - 拖拽创建连接"/>
             </Grid>
         </Grid>
     </Border>

--- a/WorkflowDesigner/UI/Views/Nodes/TaskNodeView.xaml
+++ b/WorkflowDesigner/UI/Views/Nodes/TaskNodeView.xaml
@@ -1,4 +1,4 @@
-﻿<local:DraggableNodeViewBase x:TypeArguments="vm:TaskNodeViewModel"
+<local:DraggableNodeViewBase x:TypeArguments="vm:TaskNodeViewModel"
                     x:Class="WorkflowDesigner.UI.Views.Nodes.TaskNodeView"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,6 +6,7 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:local="clr-namespace:WorkflowDesigner.UI.Views.Nodes"
                     xmlns:vm="clr-namespace:WorkflowDesigner.Nodes"
+                    xmlns:nodenetwork="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
                     mc:Ignorable="d"
                     Width="140" Height="80">
     <Border Background="#F3E5F5" BorderBrush="#9C27B0" BorderThickness="2" CornerRadius="4">
@@ -27,6 +28,22 @@
                        Margin="3" Foreground="#4A148C"/>
 
             <Rectangle Grid.Row="2" Height="3" Fill="{Binding StatusBrush}" Margin="3"/>
+        </Grid>
+
+        <!-- 输入端口区域 -->
+        <Grid Grid.Row="0" HorizontalAlignment="Left" Margin="5,5,0,0">
+            <nodenetwork:NodeInputView ViewModel="{Binding Inputs[0]}"
+                                       Width="16" Height="16"
+                                       Cursor="Hand"
+                                       ToolTip="输入端口 - 接收连接"/>
+        </Grid>
+
+        <!-- 输出端口区域 -->
+        <Grid Grid.Row="2" HorizontalAlignment="Right" Margin="0,0,5,5">
+            <nodenetwork:NodeOutputView ViewModel="{Binding Outputs[0]}"
+                                        Width="16" Height="16"
+                                        Cursor="Hand"
+                                        ToolTip="输出端口 - 拖拽创建连接"/>
         </Grid>
     </Border>
 </local:DraggableNodeViewBase>


### PR DESCRIPTION
Integrate NodeNetwork PortViews into all workflow node views to enable visual connection point functionality.

The existing node views lacked `NodeInputView` and `NodeOutputView` elements, preventing the `NodeNetwork` library from handling visual port connections. This change adds the necessary XAML to enable drag-and-drop connections between nodes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a56ef269-62ad-4d5e-876d-fdef0faf55ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a56ef269-62ad-4d5e-876d-fdef0faf55ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

